### PR TITLE
Added typehints to the codebase

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -1,16 +1,26 @@
+from typing import Optional, Set, Tuple, TypeVar
+
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractBaseUser
 from django.utils.translation import gettext_lazy as _
 from rest_framework import HTTP_HEADER_ENCODING, authentication
+from rest_framework.request import Request
 
 from .exceptions import AuthenticationFailed, InvalidToken, TokenError
+from .models import TokenUser
 from .settings import api_settings
+from .tokens import Token
 
 AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 
 if not isinstance(api_settings.AUTH_HEADER_TYPES, (list, tuple)):
     AUTH_HEADER_TYPES = (AUTH_HEADER_TYPES,)
 
-AUTH_HEADER_TYPE_BYTES = {h.encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES}
+AUTH_HEADER_TYPE_BYTES: Set[bytes] = {
+    h.encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES
+}
+
+AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 
 class JWTAuthentication(authentication.BaseAuthentication):
@@ -22,11 +32,11 @@ class JWTAuthentication(authentication.BaseAuthentication):
     www_authenticate_realm = "api"
     media_type = "application/json"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.user_model = get_user_model()
 
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> Optional[Tuple[AuthUser, Token]]:
         header = self.get_header(request)
         if header is None:
             return None
@@ -39,13 +49,13 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         return self.get_user(validated_token), validated_token
 
-    def authenticate_header(self, request):
+    def authenticate_header(self, request: Request) -> str:
         return '{} realm="{}"'.format(
             AUTH_HEADER_TYPES[0],
             self.www_authenticate_realm,
         )
 
-    def get_header(self, request):
+    def get_header(self, request: Request) -> bytes:
         """
         Extracts the header containing the JSON web token from the given
         request.
@@ -58,7 +68,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         return header
 
-    def get_raw_token(self, header):
+    def get_raw_token(self, header: bytes) -> Optional[bytes]:
         """
         Extracts an unvalidated JSON web token from the given "Authorization"
         header value.
@@ -81,7 +91,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         return parts[1]
 
-    def get_validated_token(self, raw_token):
+    def get_validated_token(self, raw_token: bytes) -> Token:
         """
         Validates an encoded JSON web token and returns a validated token
         wrapper object.
@@ -106,7 +116,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
             }
         )
 
-    def get_user(self, validated_token):
+    def get_user(self, validated_token: Token) -> AuthUser:
         """
         Attempts to find and return a user using the given validated token.
         """
@@ -132,7 +142,7 @@ class JWTStatelessUserAuthentication(JWTAuthentication):
     token provided in a request header without performing a database lookup to obtain a user instance.
     """
 
-    def get_user(self, validated_token):
+    def get_user(self, validated_token: Token) -> AuthUser:
         """
         Returns a stateless user object which is backed by the given validated
         token.
@@ -148,7 +158,7 @@ class JWTStatelessUserAuthentication(JWTAuthentication):
 JWTTokenUserAuthentication = JWTStatelessUserAuthentication
 
 
-def default_user_authentication_rule(user):
+def default_user_authentication_rule(user: AuthUser) -> bool:
     # Prior to Django 1.10, inactive users could be authenticated with the
     # default `ModelBackend`.  As of Django 1.10, the `ModelBackend`
     # prevents inactive users from authenticating.  App designers can still

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional, Union
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 
@@ -11,7 +13,14 @@ class TokenBackendError(Exception):
 
 
 class DetailDictMixin:
-    def __init__(self, detail=None, code=None):
+    default_detail: str
+    default_code: str
+
+    def __init__(
+        self,
+        detail: Union[Dict[str, Any], str, None] = None,
+        code: Optional[str] = None,
+    ) -> None:
         """
         Builds a detail dictionary for the error to give more information to API
         users.
@@ -26,7 +35,7 @@ class DetailDictMixin:
         if code is not None:
             detail_dict["code"] = code
 
-        super().__init__(detail_dict)
+        super().__init__(detail_dict)  # type: ignore
 
 
 class AuthenticationFailed(DetailDictMixin, exceptions.AuthenticationFailed):

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
 from django.contrib.auth import models as auth_models
 from django.db.models.manager import EmptyManager
 from django.utils.functional import cached_property
 
 from .settings import api_settings
+
+if TYPE_CHECKING:
+    from .tokens import Token
 
 
 class TokenUser:
@@ -22,87 +27,89 @@ class TokenUser:
     _groups = EmptyManager(auth_models.Group)
     _user_permissions = EmptyManager(auth_models.Permission)
 
-    def __init__(self, token):
+    def __init__(self, token: "Token") -> None:
         self.token = token
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"TokenUser {self.id}"
 
     @cached_property
-    def id(self):
+    def id(self) -> Union[int, str]:
         return self.token[api_settings.USER_ID_CLAIM]
 
     @cached_property
-    def pk(self):
+    def pk(self) -> Union[int, str]:
         return self.id
 
     @cached_property
-    def username(self):
+    def username(self) -> str:
         return self.token.get("username", "")
 
     @cached_property
-    def is_staff(self):
+    def is_staff(self) -> bool:
         return self.token.get("is_staff", False)
 
     @cached_property
-    def is_superuser(self):
+    def is_superuser(self) -> bool:
         return self.token.get("is_superuser", False)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TokenUser):
+            return NotImplemented
         return self.id == other.id
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
-    def save(self):
+    def save(self) -> None:
         raise NotImplementedError("Token users have no DB representation")
 
-    def delete(self):
+    def delete(self) -> None:
         raise NotImplementedError("Token users have no DB representation")
 
-    def set_password(self, raw_password):
+    def set_password(self, raw_password: str) -> None:
         raise NotImplementedError("Token users have no DB representation")
 
-    def check_password(self, raw_password):
+    def check_password(self, raw_password: str) -> None:
         raise NotImplementedError("Token users have no DB representation")
 
     @property
-    def groups(self):
+    def groups(self) -> auth_models.Group:
         return self._groups
 
     @property
-    def user_permissions(self):
+    def user_permissions(self) -> auth_models.Permission:
         return self._user_permissions
 
-    def get_group_permissions(self, obj=None):
+    def get_group_permissions(self, obj: Optional[object] = None) -> set:
         return set()
 
-    def get_all_permissions(self, obj=None):
+    def get_all_permissions(self, obj: Optional[object] = None) -> set:
         return set()
 
-    def has_perm(self, perm, obj=None):
+    def has_perm(self, perm: str, obj: Optional[object] = None) -> bool:
         return False
 
-    def has_perms(self, perm_list, obj=None):
+    def has_perms(self, perm_list: List[str], obj: Optional[object] = None) -> bool:
         return False
 
-    def has_module_perms(self, module):
+    def has_module_perms(self, module: str) -> bool:
         return False
 
     @property
-    def is_anonymous(self):
+    def is_anonymous(self) -> bool:
         return False
 
     @property
-    def is_authenticated(self):
+    def is_authenticated(self) -> bool:
         return True
 
-    def get_username(self):
+    def get_username(self) -> str:
         return self.username
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Optional[Any]:
         """This acts as a backup attribute getter for custom claims defined in Token serializers."""
         return self.token.get(attr, None)

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any, Dict
 
 from django.conf import settings
 from django.test.signals import setting_changed
@@ -59,7 +60,7 @@ REMOVED_SETTINGS = (
 
 
 class APISettings(_APISettings):  # pragma: no cover
-    def __check_user_settings(self, user_settings):
+    def __check_user_settings(self, user_settings: Dict[str, Any]) -> Dict[str, Any]:
         SETTINGS_DOC = "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
 
         for setting in REMOVED_SETTINGS:
@@ -80,7 +81,7 @@ class APISettings(_APISettings):  # pragma: no cover
 api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)
 
 
-def reload_api_settings(*args, **kwargs):  # pragma: no cover
+def reload_api_settings(*args, **kwargs) -> None:  # pragma: no cover
     global api_settings
 
     setting, value = kwargs["setting"], kwargs["value"]

--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -1,7 +1,16 @@
-from django.contrib import admin
-from django.utils.translation import gettext_lazy as _
+from datetime import datetime
+from typing import Any, List, Optional, TypeVar
 
+from django.contrib import admin
+from django.contrib.auth.models import AbstractBaseUser
+from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
+from rest_framework.request import Request
+
+from ..models import TokenUser
 from .models import BlacklistedToken, OutstandingToken
+
+AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 
 class OutstandingTokenAdmin(admin.ModelAdmin):
@@ -17,7 +26,7 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
     )
     ordering = ("user",)
 
-    def get_queryset(self, *args, **kwargs):
+    def get_queryset(self, *args, **kwargs) -> QuerySet:
         qs = super().get_queryset(*args, **kwargs)
 
         return qs.select_related("user")
@@ -25,16 +34,18 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
     # Read-only behavior defined below
     actions = None
 
-    def get_readonly_fields(self, *args, **kwargs):
+    def get_readonly_fields(self, *args, **kwargs) -> List[Any]:
         return [f.name for f in self.model._meta.fields]
 
-    def has_add_permission(self, *args, **kwargs):
+    def has_add_permission(self, *args, **kwargs) -> bool:
         return False
 
-    def has_delete_permission(self, *args, **kwargs):
+    def has_delete_permission(self, *args, **kwargs) -> bool:
         return False
 
-    def has_change_permission(self, request, obj=None):
+    def has_change_permission(
+        self, request: Request, obj: Optional[object] = None
+    ) -> bool:
         return request.method in ["GET", "HEAD"] and super().has_change_permission(
             request, obj
         )
@@ -57,34 +68,34 @@ class BlacklistedTokenAdmin(admin.ModelAdmin):
     )
     ordering = ("token__user",)
 
-    def get_queryset(self, *args, **kwargs):
+    def get_queryset(self, *args, **kwargs) -> QuerySet:
         qs = super().get_queryset(*args, **kwargs)
 
         return qs.select_related("token__user")
 
-    def token_jti(self, obj):
+    def token_jti(self, obj: BlacklistedToken) -> str:
         return obj.token.jti
 
-    token_jti.short_description = _("jti")
-    token_jti.admin_order_field = "token__jti"
+    token_jti.short_description = _("jti")  # type: ignore
+    token_jti.admin_order_field = "token__jti"  # type: ignore
 
-    def token_user(self, obj):
+    def token_user(self, obj: BlacklistedToken) -> AuthUser:
         return obj.token.user
 
-    token_user.short_description = _("user")
-    token_user.admin_order_field = "token__user"
+    token_user.short_description = _("user")  # type: ignore
+    token_user.admin_order_field = "token__user"  # type: ignore
 
-    def token_created_at(self, obj):
+    def token_created_at(self, obj: BlacklistedToken) -> datetime:
         return obj.token.created_at
 
-    token_created_at.short_description = _("created at")
-    token_created_at.admin_order_field = "token__created_at"
+    token_created_at.short_description = _("created at")  # type: ignore
+    token_created_at.admin_order_field = "token__created_at"  # type: ignore
 
-    def token_expires_at(self, obj):
+    def token_expires_at(self, obj: BlacklistedToken) -> datetime:
         return obj.token.expires_at
 
-    token_expires_at.short_description = _("expires at")
-    token_expires_at.admin_order_field = "token__expires_at"
+    token_expires_at.short_description = _("expires at")  # type: ignore
+    token_expires_at.admin_order_field = "token__expires_at"  # type: ignore
 
 
 admin.site.register(BlacklistedToken, BlacklistedTokenAdmin)

--- a/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
+++ b/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
@@ -8,5 +8,5 @@ from ...models import OutstandingToken
 class Command(BaseCommand):
     help = "Flushes any expired tokens in the outstanding token list"
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args, **kwargs) -> None:
         OutstandingToken.objects.filter(expires_at__lte=aware_utcnow()).delete()

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -25,7 +25,7 @@ class OutstandingToken(models.Model):
         )
         ordering = ("user",)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Token for {} ({})".format(
             self.user,
             self.jti,
@@ -48,5 +48,5 @@ class BlacklistedToken(models.Model):
             "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Blacklisted token for {self.token.user}"

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,32 +1,33 @@
 from calendar import timegm
 from datetime import datetime, timezone
+from typing import Callable
 
 from django.conf import settings
 from django.utils.functional import lazy
 from django.utils.timezone import is_naive, make_aware
 
 
-def make_utc(dt):
+def make_utc(dt: datetime) -> datetime:
     if settings.USE_TZ and is_naive(dt):
         return make_aware(dt, timezone=timezone.utc)
 
     return dt
 
 
-def aware_utcnow():
+def aware_utcnow() -> datetime:
     return make_utc(datetime.utcnow())
 
 
-def datetime_to_epoch(dt):
+def datetime_to_epoch(dt: datetime) -> int:
     return timegm(dt.utctimetuple())
 
 
-def datetime_from_epoch(ts):
+def datetime_from_epoch(ts: float) -> datetime:
     return make_utc(datetime.utcfromtimestamp(ts))
 
 
-def format_lazy(s, *args, **kwargs):
+def format_lazy(s: str, *args, **kwargs) -> str:
     return s.format(*args, **kwargs)
 
 
-format_lazy = lazy(format_lazy, str)
+format_lazy: Callable = lazy(format_lazy, str)

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,6 +1,8 @@
 from django.utils.module_loading import import_string
 from rest_framework import generics, status
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.serializers import Serializer
 
 from . import serializers
 from .authentication import AUTH_HEADER_TYPES
@@ -17,7 +19,7 @@ class TokenViewBase(generics.GenericAPIView):
 
     www_authenticate_realm = "api"
 
-    def get_serializer_class(self):
+    def get_serializer_class(self) -> Serializer:
         """
         If serializer_class is set, use it directly. Otherwise get the class from settings.
         """
@@ -30,13 +32,13 @@ class TokenViewBase(generics.GenericAPIView):
             msg = "Could not import serializer '%s'" % self._serializer_class
             raise ImportError(msg)
 
-    def get_authenticate_header(self, request):
+    def get_authenticate_header(self, request: Request) -> str:
         return '{} realm="{}"'.format(
             AUTH_HEADER_TYPES[0],
             self.www_authenticate_realm,
         )
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args, **kwargs) -> Response:
         serializer = self.get_serializer(data=request.data)
 
         try:


### PR DESCRIPTION
## What
Added typehints

## Discussion
- Used AuthUser as a TypeVar to type the dynamic django user model. Went with the assumption that the User model would always be inheriting from the AbstractBaseUser, but not sure if that is really always the case. Also added the TokenUser to it to account for the JWTStatelessUserAuthentication. Not sure if this is the best implementation for this.
- Mixin and inheritance issues. Currently, the problem with mixins and some inherintances, is that the other (parent) class can’t always be deduced by mypy, which gives some warnings.
- Usage of `type: ignore` at a few places. Not sure if that’s something we would want, as it could also mask problems that might want to be tackled in the future.
- Not really happy with the readability of using Union and Optional, the “|” union operator could make it a bit better, but was only added in 3.10

## Issues related to the tox configuration
- Noticed django2.2 references in the envlist of the tox.ini file, which caused some errors running the tests locally. As django2.2 is not supported anymore now, this could maybe be updated?
- Additionally, the djmain tests were also failing locally due to this:
```
* The undocumented ``django.http.multipartparser.parse_header()`` function is
 removed. Use ``django.utils.http.parse_header_parameters()`` instead.
```
Not sure if that’s something we should worry about. It seems that djmain doesn’t play nice with drf3.13, which has been fixed in drf3.14.

Could possibly be picked up in a separate PR. Let me know what you think of it.

## Future…
- Possibly adding Type checking with mypy in the future? Currently, mypy is still returning some warnings. So this would require some additional work regarding typing. Additionally, a mypy configuration has to be defined. Not sure if this is something you would like to see in the future.

## Finally
Feedback/suggestions are welcome! Will happily make adjustments wherever necessary. :)