### PR TITLE
Removing dj-22 and djmain from the tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist=
-    py{37,38,39}-dj22-drf310-pyjwt{171,2}-tests
-    py{37,38,39,310}-dj{22,32}-drf{311,312,313}-pyjwt{171,2}-tests
-    py{38,39,310}-dj{40,41,main}-drf313-pyjwt{171,2}-tests
-    py311-dj{41,main}-drf313-pyjwt{171,2}-tests
+    py{37,38,39,310}-dj32-drf{311,312,313}-pyjwt{171,2}-tests
+    py{38,39,310}-dj{40,41}-drf313-pyjwt{171,2}-tests
+    py311-dj41-drf313-pyjwt{171,2}-tests
     docs
 
 [gh-actions]
@@ -43,7 +42,6 @@ deps=
     drf313: djangorestframework>=3.13,<3.14
     pyjwt171: pyjwt>=1.7.1,<1.8
     pyjwt2: pyjwt>=2,<3
-    djmain: https://github.com/django/django/archive/main.tar.gz
 allowlist_externals=make
 
 [testenv:docs]


### PR DESCRIPTION
To follow the Github Actions pipeline, with this PR Django2.2 and Django main branch are removed from the local tests with Tox.

[Removal of dj22 and djmain from Github Actions](https://github.com/jazzband/djangorestframework-simplejwt/pull/677)